### PR TITLE
Fix composer-script-utils version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,69 @@
 Wordpress Skeleton Installer
 ==================
 
-Install scripts to work with [wp-skeleton](https://github.com/wemakecustom/wp-skeleton).
+Will be installed with [wp-skeleton][1].
+
 
 ## What it does
 
-- install _WordPress_ with composer :
-  * johnpbloch/wordpress (version ^4.0)
-  * wemakecustom/wp-pot-generator (version ~2.0@dev)
-  * wemakecustom/composer-script-utils
-  * wp-cli/wp-cli
-- create plugins, mu-plugins, themes folders into _/htdocs/wp-content/_
-- add the default .gitignore for wordpress.
-- executed scripts before and after each update/install with composer to ensure a stable environement.
-- add new binaries dependencies :
-  * bin/rename-prefix.php _(help to change wordpress tables prefix)_
-  * bin/update-wpskeleton.php
+Install WordPress and dependencies:
+* [wemakecustom/composer-script-utils][2] (version ^1.0)
+* [wp-cli/wp-cli][3]
+* [johnpbloch/wordpress][4] (version ^4.0)
+* [wemakecustom/wp-pot-generator][5] (version ~2.0@dev)
+
+Add all default folders and files needed:
+* create plugins, mu-plugins, themes folders into ``/htdocs/wp-content/``
+* add the default ``.gitignore`` for wordpress.
+* executed scripts before and after each update/install with composer to ensure a stable environement.
+
+[1]: https://github.com/wemakecustom/wp-skeleton
+[2]: https://github.com/wemakecustom/composer-script-utils
+[3]: https://github.com/wp-cli/wp-cli
+[4]: https://github.com/johnpbloch/wordpress
+[5]: https://github.com/wemakecustom/wp-pot-generator
+
 
 ## Installation
 
-Clone this git repo.
 ````
-$ git clone git@github.com:wemakecustom/wp-skeleton-installer.git
-````
-Run composer to install.
-````
+$ git clone git@github.com:wemakecustom/wp-skeleton-installer.git <project>
+$ cd <project>
 $ composer install
 ````
-You will see a prompt message to set default database information, WPLANG and WP_DEBUG.
 
-## Scripts executed for each update and install
+You will see prompt messages to set default database information, wordpress language and debug parameters.
 
-* ScriptHandler::installMuRequire _(install all must-use plugins)_
-* ScriptHandler::rsync _(move files from temporary to destination folder)_
-* ScriptHandler::verifyGitignore _(install default .gitignore)_
-* ScriptHandler::installWpConfig _(install default .wp-config.php)_
-* ScriptHandler::configureAbspath _(set the ABSPath for /htdocs/)_
-* ScriptHandler::updateConfigs _(update config's files with database and basics configuration needed for WordPress)_
-* ScriptHandler::wordpressSymlinks _(create symlink to WordPress files (except for license.txt, readme.html, composer.json, wp-config-sample.php, wp-config.php, /wp-content/)_
-* ScriptHandler::generateRandomKeys _(set random variables for encryption of information stored in the user's cookies)_
+``ScriptHandler`` manage the installation:
+* install must-use plugins;
+* move and create symlink to WordPress files and folders;
+* manage config's files (database and basics configuration needed for WordPress);
+* set SALT keys for encryption of information stored in the user's cookies
+
+By default, at the end, you will get WordPress and all configs files installed in ``<project>/test/`` subfolder. To configure another subfolder, please see section _configuration_ bellow.
+
 
 ## Configuration
 
+The following section in ``composer.json`` allow you to change the folder where WordPress and the config files are installed.
+For an example to see how to change this section, please see [wp-skeleton][1].
+
 ```json
 {
-    "require": {
-        "wemakecustom/wp-skeleton-installer": "*",
-    },
-    "scripts": {
-        "post-install-cmd": [
-            "WMC\\Wordpress\\SkeletonInstaller\\Composer\\ScriptHandler::handle",
-        ],
-        "post-update-cmd": [
-            "WMC\\Wordpress\\SkeletonInstaller\\Composer\\ScriptHandler::handle",
-        ]
-    },
     "extra": {
         "wordpress-install-dir": "vendor/wordpress/wordpress",
+        "confs-dir": "test/confs",
+        "web-dir": "test/htdocs",
+        "installer-paths": {
+            "test/htdocs/wp-content/plugins/{$name}/": ["type:wordpress-plugin"],
+            "test/htdocs/wp-content/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
+            "test/htdocs/wp-content/themes/composer/{$name}/": ["type:wordpress-theme"]
+        }
     }
 }
 ```
 
-## Installation
-- https://github.com/wemakecustom/wp-skeleton
-- https://github.com/johnpbloch/wordpress
-- https://github.com/wemakecustom/wp-mu-loader
-- https://github.com/wemakecustom/wp-pot-generator
-- https://github.com/wp-cli/wp-cli
-- https://github.com/wemakecustom/composer-script-utils
+So, you can change:
+* ``wordpress-install-dir`` to specify where you want to install WordPress core.
+* ``confs-dir`` to define where you install config's files _(ie database)_.
+* ``web-dir`` to set the subfolder for WordPress, where core symlinks, themes and plugins will be installed. **You will work in this subfolder**.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "johnpbloch/wordpress": "^4.0",
         "wp-cli/wp-cli": "*",
-        "wemakecustom/composer-script-utils": "*",
+        "wemakecustom/composer-script-utils": "^1.0",
         "wemakecustom/wp-pot-generator": "~2.0@dev"
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,25 +4,25 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2fa640aff6982e03d3841ef282bfc483",
-    "content-hash": "35273eaf352e13d1c9bc9ba6a2ccef78",
+    "hash": "74a1e6b4e9e24733b1bec943fed99571",
+    "content-hash": "3495640849cbe01c2e5c8aa447a4273b",
     "packages": [
         {
             "name": "composer/installers",
-            "version": "v1.0.22",
+            "version": "v1.0.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "bd9b14f094c89c8b5804a4e41edeb7853bb85046"
+                "reference": "36e5b5843203d7f1cf6ffb0305a97e014387bd8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/bd9b14f094c89c8b5804a4e41edeb7853bb85046",
-                "reference": "bd9b14f094c89c8b5804a4e41edeb7853bb85046",
+                "url": "https://api.github.com/repos/composer/installers/zipball/36e5b5843203d7f1cf6ffb0305a97e014387bd8e",
+                "reference": "36e5b5843203d7f1cf6ffb0305a97e014387bd8e",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "1.0.0"
+                "composer-plugin-api": "^1.0"
             },
             "replace": {
                 "roundcube/plugin-installer": "*",
@@ -40,8 +40,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Composer\\Installers\\": "src/"
+                "psr-4": {
+                    "Composer\\Installers\\": "src/Composer/Installers"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -56,12 +56,14 @@
                 }
             ],
             "description": "A multi-framework Composer library installer",
-            "homepage": "http://composer.github.com/installers/",
+            "homepage": "https://composer.github.io/installers/",
             "keywords": [
                 "Craft",
                 "Dolibarr",
                 "Hurad",
+                "ImageCMS",
                 "MODX Evo",
+                "Mautic",
                 "OXID",
                 "SMF",
                 "Thelia",
@@ -103,20 +105,81 @@
                 "zend",
                 "zikula"
             ],
-            "time": "2015-10-29 23:28:48"
+            "time": "2016-04-13 19:46:30"
         },
         {
-            "name": "johnpbloch/wordpress",
-            "version": "4.3.1",
+            "name": "composer/semver",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/johnpbloch/wordpress.git",
-                "reference": "cfcf25eb42baeb7316a61c7a64e9a1ab3e291f2f"
+                "url": "https://github.com/composer/semver.git",
+                "reference": "d0e1ccc6d44ab318b758d709e19176037da6b1ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress/zipball/cfcf25eb42baeb7316a61c7a64e9a1ab3e291f2f",
-                "reference": "cfcf25eb42baeb7316a61c7a64e9a1ab3e291f2f",
+                "url": "https://api.github.com/repos/composer/semver/zipball/d0e1ccc6d44ab318b758d709e19176037da6b1ba",
+                "reference": "d0e1ccc6d44ab318b758d709e19176037da6b1ba",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5",
+                "phpunit/phpunit-mock-objects": "~2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com"
+                },
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "time": "2015-09-21 09:42:36"
+        },
+        {
+            "name": "johnpbloch/wordpress",
+            "version": "4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/johnpbloch/wordpress.git",
+                "reference": "a975896d0806f3dc1ccf3e170f91226440b267cb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress/zipball/a975896d0806f3dc1ccf3e170f91226440b267cb",
+                "reference": "a975896d0806f3dc1ccf3e170f91226440b267cb",
                 "shasum": ""
             },
             "require": {
@@ -140,7 +203,7 @@
                 "blog",
                 "cms"
             ],
-            "time": "2015-09-15 15:01:23"
+            "time": "2016-04-12 17:46:20"
         },
         {
             "name": "johnpbloch/wordpress-core-installer",
@@ -192,16 +255,16 @@
         },
         {
             "name": "mustache/mustache",
-            "version": "v2.9.0",
+            "version": "v2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/mustache.php.git",
-                "reference": "c745b01956caf27d26b55a72a90aff56bc169cd6"
+                "reference": "0bb2f76e2f34a8864a32be34c4ec66274d76c05e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/mustache.php/zipball/c745b01956caf27d26b55a72a90aff56bc169cd6",
-                "reference": "c745b01956caf27d26b55a72a90aff56bc169cd6",
+                "url": "https://api.github.com/repos/bobthecow/mustache.php/zipball/0bb2f76e2f34a8864a32be34c4ec66274d76c05e",
+                "reference": "0bb2f76e2f34a8864a32be34c4ec66274d76c05e",
                 "shasum": ""
             },
             "require": {
@@ -209,7 +272,7 @@
             },
             "require-dev": {
                 "fabpot/php-cs-fixer": "~1.6",
-                "phpunit/phpunit": "~3.7|~4.0"
+                "phpunit/phpunit": "~3.7|~4.0|~5.0"
             },
             "type": "library",
             "autoload": {
@@ -234,7 +297,54 @@
                 "mustache",
                 "templating"
             ],
-            "time": "2015-08-15 19:23:13"
+            "time": "2016-02-27 19:22:46"
+        },
+        {
+            "name": "mustangostang/spyc",
+            "version": "0.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mustangostang/spyc.git",
+                "reference": "dc4785b4d7227fd9905e086d499fb8abfadf9977"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mustangostang/spyc/zipball/dc4785b4d7227fd9905e086d499fb8abfadf9977",
+                "reference": "dc4785b4d7227fd9905e086d499fb8abfadf9977",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.5.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Spyc.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT License"
+            ],
+            "authors": [
+                {
+                    "name": "mustangostang",
+                    "email": "vlad.andersen@gmail.com"
+                }
+            ],
+            "description": "A simple YAML loader/dumper class for PHP",
+            "homepage": "https://github.com/mustangostang/spyc/",
+            "keywords": [
+                "spyc",
+                "yaml",
+                "yml"
+            ],
+            "time": "2013-02-21 10:52:01"
         },
         {
             "name": "nb/oxymel",
@@ -372,17 +482,300 @@
             "time": "2014-05-18 04:59:02"
         },
         {
-            "name": "symfony/finder",
-            "version": "v2.7.6",
+            "name": "symfony/config",
+            "version": "v2.7.11",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "2ffb4e9598db3c48eb6d0ae73b04bbf09280c59d"
+                "url": "https://github.com/symfony/config.git",
+                "reference": "ba8afdf1f62d445237c0cddc6735ab5172837ad4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/2ffb4e9598db3c48eb6d0ae73b04bbf09280c59d",
-                "reference": "2ffb4e9598db3c48eb6d0ae73b04bbf09280c59d",
+                "url": "https://api.github.com/repos/symfony/config/zipball/ba8afdf1f62d445237c0cddc6735ab5172837ad4",
+                "reference": "ba8afdf1f62d445237c0cddc6735ab5172837ad4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9",
+                "symfony/filesystem": "~2.3"
+            },
+            "suggest": {
+                "symfony/yaml": "To use the yaml reference dumper"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Config Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-03-04 07:52:28"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v2.7.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "6100a40569b2be1b6aba1cc6a92fe6cb71024fc8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/6100a40569b2be1b6aba1cc6a92fe6cb71024fc8",
+                "reference": "6100a40569b2be1b6aba1cc6a92fe6cb71024fc8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "~2.1",
+                "symfony/process": "~2.1"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-03-09 16:30:49"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v2.7.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "cac43a600917c72764ba84f5ea3c43690e5c451a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/cac43a600917c72764ba84f5ea3c43690e5c451a",
+                "reference": "cac43a600917c72764ba84f5ea3c43690e5c451a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "conflict": {
+                "symfony/expression-language": "<2.6"
+            },
+            "require-dev": {
+                "symfony/config": "~2.2",
+                "symfony/expression-language": "~2.6",
+                "symfony/yaml": "~2.1"
+            },
+            "suggest": {
+                "symfony/config": "",
+                "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DependencyInjection Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-03-10 10:49:29"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v2.7.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "b7c955d4a2fa79fca9caccdaaa5434e3799e3b51"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b7c955d4a2fa79fca9caccdaaa5434e3799e3b51",
+                "reference": "b7c955d4a2fa79fca9caccdaaa5434e3799e3b51",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.0,>=2.0.5",
+                "symfony/dependency-injection": "~2.6",
+                "symfony/expression-language": "~2.6",
+                "symfony/stopwatch": "~2.3"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-03-06 17:01:13"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v2.7.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "3b33a681af5e283cc96431118c336024ed78e556"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3b33a681af5e283cc96431118c336024ed78e556",
+                "reference": "3b33a681af5e283cc96431118c336024ed78e556",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-03-16 16:00:15"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v2.7.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "0bacc7c9fc1905cfce20212633013a5b300dce52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/0bacc7c9fc1905cfce20212633013a5b300dce52",
+                "reference": "0bacc7c9fc1905cfce20212633013a5b300dce52",
                 "shasum": ""
             },
             "require": {
@@ -397,7 +790,10 @@
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Finder\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -415,20 +811,132 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-11 09:39:48"
+            "time": "2016-03-10 10:49:29"
         },
         {
-            "name": "wemakecustom/composer-script-utils",
-            "version": "v0.5",
+            "name": "symfony/translation",
+            "version": "v2.7.11",
             "source": {
                 "type": "git",
-                "url": "https://github.com/wemakecustom/composer-script-utils.git",
-                "reference": "a1e02411e9dca3fd955e1eafa39e6218334c1b8e"
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "e75d88c9af3c9c06341f4dad7ce776c9bddf94de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wemakecustom/composer-script-utils/zipball/a1e02411e9dca3fd955e1eafa39e6218334c1b8e",
-                "reference": "a1e02411e9dca3fd955e1eafa39e6218334c1b8e",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/e75d88c9af3c9c06341f4dad7ce776c9bddf94de",
+                "reference": "e75d88c9af3c9c06341f4dad7ce776c9bddf94de",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "conflict": {
+                "symfony/config": "<2.7"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.7",
+                "symfony/intl": "~2.4",
+                "symfony/yaml": "~2.2"
+            },
+            "suggest": {
+                "psr/log": "To use logging capability in translator",
+                "symfony/config": "",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Translation Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-03-24 09:06:43"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.7.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "e9877e0c01cdb4f3daf04784b2a8315ee8cb5b68"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/e9877e0c01cdb4f3daf04784b2a8315ee8cb5b68",
+                "reference": "e9877e0c01cdb4f3daf04784b2a8315ee8cb5b68",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-03-04 07:52:28"
+        },
+        {
+            "name": "wemakecustom/composer-script-utils",
+            "version": "v1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wemakecustom/composer-script-utils.git",
+                "reference": "31125b3ba97c9858531c3ea4b1a25d141a69f84b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wemakecustom/composer-script-utils/zipball/31125b3ba97c9858531c3ea4b1a25d141a69f84b",
+                "reference": "31125b3ba97c9858531c3ea4b1a25d141a69f84b",
                 "shasum": ""
             },
             "require-dev": {
@@ -455,15 +963,14 @@
             "authors": [
                 {
                     "name": "Sébastien Lavoie",
-                    "email": "seb@wemakecustom.com",
-                    "homepage": "http://www.wemakecustom.com"
+                    "email": "seb@wemakecustom.com"
                 }
             ],
             "description": "Set of tools for Composer scripts",
             "keywords": [
                 "composer"
             ],
-            "time": "2014-07-07 15:56:11"
+            "time": "2016-02-26 19:14:06"
         },
         {
             "name": "wemakecustom/wp-pot-generator",
@@ -510,16 +1017,16 @@
         },
         {
             "name": "wp-cli/php-cli-tools",
-            "version": "v0.10.5",
+            "version": "v0.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/php-cli-tools.git",
-                "reference": "037a010441a5c220cd1df26cdc9b20ad73408356"
+                "reference": "d0564da283585c7289e18877ed2f9c35c1b67013"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/037a010441a5c220cd1df26cdc9b20ad73408356",
-                "reference": "037a010441a5c220cd1df26cdc9b20ad73408356",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/d0564da283585c7289e18877ed2f9c35c1b67013",
+                "reference": "d0564da283585c7289e18877ed2f9c35c1b67013",
                 "shasum": ""
             },
             "require": {
@@ -556,30 +1063,39 @@
                 "cli",
                 "console"
             ],
-            "time": "2015-08-10 12:46:19"
+            "time": "2016-01-01 01:01:20"
         },
         {
             "name": "wp-cli/wp-cli",
-            "version": "v0.20.3",
+            "version": "v0.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "01cd854f4744b1729d486ef23491c0d48824f435"
+                "reference": "45460a55328db9952e0c93023c8b79a2432332d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/01cd854f4744b1729d486ef23491c0d48824f435",
-                "reference": "01cd854f4744b1729d486ef23491c0d48824f435",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/45460a55328db9952e0c93023c8b79a2432332d9",
+                "reference": "45460a55328db9952e0c93023c8b79a2432332d9",
                 "shasum": ""
             },
             "require": {
+                "composer/semver": "1.0.0",
                 "mustache/mustache": "~2.4",
+                "mustangostang/spyc": "0.5.1",
                 "nb/oxymel": "0.1.0",
                 "php": ">=5.3.2",
                 "ramsey/array_column": "~1.1",
                 "rmccue/requests": "~1.6",
-                "symfony/finder": "~2.3",
-                "wp-cli/php-cli-tools": "0.10.5"
+                "symfony/config": "2.7.*",
+                "symfony/console": "2.7.*",
+                "symfony/dependency-injection": "2.7.*",
+                "symfony/event-dispatcher": "2.7.*",
+                "symfony/filesystem": "2.7.*",
+                "symfony/finder": "2.7.*",
+                "symfony/translation": "2.7.*",
+                "symfony/yaml": "2.7.*",
+                "wp-cli/php-cli-tools": "0.11.0"
             },
             "require-dev": {
                 "behat/behat": "2.5.*",
@@ -597,9 +1113,6 @@
                 "psr-0": {
                     "WP_CLI": "php"
                 },
-                "files": [
-                    "php/Spyc.php"
-                ],
                 "classmap": [
                     "php/export"
                 ]
@@ -614,7 +1127,7 @@
                 "cli",
                 "wordpress"
             ],
-            "time": "2015-10-30 16:19:56"
+            "time": "2016-01-07 16:36:32"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
Hi,
Since the update of `wemakecustom/composer-script-utils`, some config files and folders have been moved/renamed. To avoid errors when installing `wp-skeleton-installer`, we need to set `wemakecustom/composer-script-utils` version to `~1.0`.
I also updated ReadMe information to be more easy to read.
